### PR TITLE
Support for BSON decimal option type serialization

### DIFF
--- a/src/BagnoDB.Serializator/OptionSerializer.fs
+++ b/src/BagnoDB.Serializator/OptionSerializer.fs
@@ -21,7 +21,8 @@ type OptionSerializer<'TOption when 'TOption: equality>() =
 
         let (case, args) =
             let value =
-                if (typeOfArg.IsPrimitive) then
+                if typeOfArg.IsPrimitive 
+                    || (typeOfArg = typeof<decimal> && context.Reader.CurrentBsonType = MongoDB.Bson.BsonType.Null) then
                     BsonSerializer.Deserialize(context.Reader, typeof<obj>)
                 else
                     BsonSerializer.Deserialize(context.Reader, typeOfArg)

--- a/src/BagnoDB.Serializator/OptionSerializer.fs
+++ b/src/BagnoDB.Serializator/OptionSerializer.fs
@@ -21,8 +21,8 @@ type OptionSerializer<'TOption when 'TOption: equality>() =
 
         let (case, args) =
             let value =
-                if typeOfArg.IsPrimitive 
-                    || (typeOfArg = typeof<decimal> && context.Reader.CurrentBsonType = MongoDB.Bson.BsonType.Null) then
+                let isDecimalValueNull = (typeOfArg = typeof<decimal> && context.Reader.CurrentBsonType = BsonType.Null)
+                if typeOfArg.IsPrimitive || isDecimalValueNull then
                     BsonSerializer.Deserialize(context.Reader, typeof<obj>)
                 else
                     BsonSerializer.Deserialize(context.Reader, typeOfArg)

--- a/src/BagnoDB/Serialization.fs
+++ b/src/BagnoDB/Serialization.fs
@@ -3,9 +3,13 @@ namespace BagnoDB
     open MongoDB.Bson.Serialization
     open MongoDB.Bson.Serialization.Serializers
 
+    [<RequireQualifiedAccess>]
     module Serialization =
         let bson bsonSerializer =
             BsonSerializer.RegisterSerializationProvider bsonSerializer
 
-        let registerDecimalSerializer () =
+        let typedBson<'T> bsonSerializer =
+            BsonSerializer.RegisterSerializer<'T> bsonSerializer
+
+        let registerDecimal () =
             BsonSerializer.RegisterSerializer(typeof<decimal>, DecimalSerializer MongoDB.Bson.BsonType.Decimal128)

--- a/src/BagnoDB/Serialization.fs
+++ b/src/BagnoDB/Serialization.fs
@@ -1,7 +1,11 @@
 namespace BagnoDB
 
     open MongoDB.Bson.Serialization
+    open MongoDB.Bson.Serialization.Serializers
 
     module Serialization =
         let bson bsonSerializer =
             BsonSerializer.RegisterSerializationProvider bsonSerializer
+
+        let registerDecimalSerializer () =
+            BsonSerializer.RegisterSerializer(typeof<decimal>, DecimalSerializer MongoDB.Bson.BsonType.Decimal128)

--- a/tests/BagnoDB.Serializator.IntegrationTests/Tests.fs
+++ b/tests/BagnoDB.Serializator.IntegrationTests/Tests.fs
@@ -1,6 +1,7 @@
 namespace BagnoDB.Serializator.Tests
 
 open System.Threading
+open System
 open Xunit
 open Swensen.Unquote
 open BagnoDB
@@ -45,7 +46,22 @@ type SmallestPossibleRecord =
         Foo: Union
     }
 
+type RecordOfOptionTypes = {
+    Boolean: bool option
+    Decimal: decimal option
+    float: float option
+    Int32: Int32 option
+    Int64: Int64 option
+}
+
 type SerializatorTests() =
+    do 
+        Serialization.bson (BagnoSerializationProvider ())
+        Conventions.create
+        |> Conventions.add (OptionConvention ())
+        |> Conventions.add (RecordConvention ())
+        |> Conventions.build "F# Type Conventions"
+
     let database = "BagnoDB_Serializator_IntegrationTests"
 
     let config = {
@@ -60,14 +76,6 @@ type SerializatorTests() =
             Connection.host config
             |> Connection.database database
             |> Connection.collection collection
-
-        Conventions.create
-        |> Conventions.add (OptionConvention ())
-        |> Conventions.add (RecordConvention ())
-        |> Conventions.build "F# Type Conventions"
-
-        Serialization.bson (BagnoSerializationProvider ())
-
         connection
 
     [<Fact>]
@@ -133,6 +141,52 @@ type SerializatorTests() =
         let delOpt = DeleteOptions()
         let insOpt = InsertOneOptions()
         let filterOpt = FindOptions<SmallestPossibleRecord>()
+        async {
+            let! _ = con |> Query.deleteMany CancellationToken.None delOpt wildcard
+            do! con |> Query.insertOne CancellationToken.None insOpt testCase
+            let! saved = con |> Query.filter CancellationToken.None filterOpt wildcard
+            testCase =! (saved |> Seq.head)
+        } |> Async.RunSynchronously
+
+    [<Fact>]
+    member _.``record with optional type None should be serialized/deserialized correctly`` () =
+        let wildcard = Filter.empty
+        let testCase: RecordOfOptionTypes = {
+            Boolean = None
+            Decimal = None
+            float = None
+            Int32 = None
+            Int64 = None
+        }
+
+        let con = connection "RecordOptionType_None_Tests"
+        let delOpt = DeleteOptions()
+        let insOpt = InsertOneOptions()
+        let filterOpt = FindOptions<RecordOfOptionTypes>()
+
+        async {
+            let! _ = con |> Query.deleteMany CancellationToken.None delOpt wildcard
+            do! con |> Query.insertOne CancellationToken.None insOpt testCase
+            let! saved = con |> Query.filter CancellationToken.None filterOpt wildcard
+            testCase =! (saved |> Seq.head)
+        } |> Async.RunSynchronously
+
+    [<Fact>]
+    member _.``record with optional type fields all Some value should be serialized/deserialized correctly`` () =
+        let wildcard = Filter.empty
+        let testCase: RecordOfOptionTypes = {
+            Boolean = Some true
+            Decimal = Some 1M
+            float = Some 1.0
+            Int32 = Some 1
+            Int64 = Some 1L
+        }
+
+        let con = connection "RecordOptionType_Some_Tests"
+        let delOpt = DeleteOptions()
+        let insOpt = InsertOneOptions()
+        let filterOpt = FindOptions<RecordOfOptionTypes>()
+
         async {
             let! _ = con |> Query.deleteMany CancellationToken.None delOpt wildcard
             do! con |> Query.insertOne CancellationToken.None insOpt testCase


### PR DESCRIPTION
- MongoDB 3.4+ BSON decimal 128 support. 
- Also, backwards compatible when not registering the DecimalSerializer  (string are used).



